### PR TITLE
feat: throw exceptions instead of exit_failure for file-related fatal errors

### DIFF
--- a/include/gt_file_errors.h
+++ b/include/gt_file_errors.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <exception>
+#include <string>
+#include <cstring>
+
+class GTFileOpenError : public std::exception {
+private:
+  std::string errstr;
+public:
+  GTFileOpenError(std::string errstr) : errstr(errstr) {};
+  virtual const char* what() const throw() {
+    std::string temp = "Failed to open backing storage file! error=" + errstr + "\n";
+    return temp.c_str();
+  }
+};
+
+class GTFileReadError : public std::exception {
+private:
+  std::string errstr;
+  int id;
+public:
+  GTFileReadError(std::string errstr, int id) : errstr(errstr), id(id) {};
+  virtual const char* what() const throw() {
+    std::string temp = "ERROR: failed to read from buffer " + std::to_string(id) + ". \"" + errstr + "\"\n";
+    return temp.c_str();
+  }
+};
+
+class GTFileWriteError : public std::exception {
+private:
+  std::string errstr;
+  int id;
+public:
+  GTFileWriteError(std::string errstr, int id) : errstr(errstr), id(id) {};
+  virtual const char* what() const throw() {
+    std::string temp = "ERROR: flush failed to write to buffer " + std::to_string(id) + ". \"" + errstr + "\"\n";
+    return temp.c_str();
+  }
+};

--- a/include/gutter_tree.h
+++ b/include/gutter_tree.h
@@ -28,7 +28,8 @@ private:
   flush_struct *flush_data;
 
   /*
-   * Functions for flushing the roots of our subtrees and for the BufferFlushers to call
+   * Functions for flushing the roots of our subtrees and for the BufferFlushers to call.
+   * Throws GTFileReadError if there is an error reading from a buffer.
    */
   flush_ret_t flush_internal_node(flush_struct &flush_from, BufferControlBlock *bcb);
   flush_ret_t flush_leaf_node(flush_struct &flush_from, BufferControlBlock *bcb);
@@ -90,9 +91,11 @@ public:
    * Generates a new homebrew buffer tree.
    * @param dir     file path of the data structure root directory, relative to
    *                the executing workspace.
-   * @param nodes   number of nodes in the graph
-   * @param workers the number of workers which will be using this buffer tree (defaults to 1)
-   * @param reset   should truncate the file storage upon opening
+   * @param nodes   number of nodes in the graph.
+   * @param workers the number of workers which will be using this buffer tree (defaults to 1).
+   * @param reset   should truncate the file storage upon opening.
+   * 
+   * @throw GTFileOpenError if the backing file cannot be opened.
    */
   GutterTree(std::string dir, node_id_t nodes, int workers, bool reset);
   ~GutterTree();
@@ -121,6 +124,8 @@ public:
    * Functions for flushing bcbs or subtrees of the graph
    * @param flush_from      The memory to use when flushing - associated with a given thread
    * @param bcb             The buffer_control_block to flush
+   * 
+   * @throw GTFileReadError if there is an error reading from a buffer.
    */
   flush_ret_t flush_subtree(flush_struct &flush_from, BufferControlBlock *bcb);
   flush_ret_t flush_control_block(flush_struct &flush_from, BufferControlBlock *bcb);

--- a/src/buffer_control_block.cpp
+++ b/src/buffer_control_block.cpp
@@ -1,5 +1,6 @@
 #include "../include/buffer_control_block.h"
 #include "../include/gutter_tree.h"
+#include "../include/gt_file_errors.h"
 
 #include <unistd.h>
 #include <errno.h>
@@ -30,8 +31,7 @@ bool BufferControlBlock::write(GutterTree *gt, char *data, uint32_t size) {
   int w = 0;
   while(len < (int32_t)size) {
     if (len == -1) {
-      printf("ERROR: write to buffer %i failed %s\n", id, strerror(errno));
-      exit(EXIT_FAILURE);
+      throw GTFileWriteError(strerror(errno), id);
     }
     w    += len;
     size -= len;


### PR DESCRIPTION
- Throw exceptions for fatal file open/read/write errors to be caught by the streaming setup so teardown can still happen
- Do not provide any support machinery other than the error message