### PR TITLE
fix to update repos when contents change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,7 @@ endif()
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG "release-1.11.0"
-
-  UPDATE_DISCONNECTED OFF
+  GIT_TAG        release-1.11.0
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
@@ -56,10 +54,8 @@ endif()
 FetchContent_Declare(
   GraphZeppelinCommon
 
-  GIT_REPOSITORY  "https://github.com/GraphStreamingProject/GraphZeppelinCommon.git"
-  GIT_TAG         "main"
-
-  UPDATE_DISCONNECTED OFF
+  GIT_REPOSITORY  https://github.com/GraphStreamingProject/GraphZeppelinCommon.git
+  GIT_TAG         main
 )
 
 FetchContent_MakeAvailable(googletest GraphZeppelinCommon)


### PR DESCRIPTION
Previously running `cmake ..` would not pull in updates from our other repos. This small change fixes this issue.