### PR TITLE
Added peek_batch_callback and fix compiler warnings

### DIFF
--- a/include/guttering_system.h
+++ b/include/guttering_system.h
@@ -26,10 +26,12 @@ public:
   }
 
   // get data out of the guttering system either one gutter at a time or in a batched fashion
-  bool get_data_batched(std::vector<WorkQueue::DataNode *> &batched_data, int batch_size) 
-    { return wq.peek_batch(batched_data, batch_size); }
   bool get_data(WorkQueue::DataNode *&data) { return wq.peek(data); }
   void get_data_callback(WorkQueue::DataNode *data) { wq.peek_callback(data); }
+  bool get_data_batched(std::vector<WorkQueue::DataNode *> &batched_data, int batch_size) 
+    { return wq.peek_batch(batched_data, batch_size); }
+  void get_data_batched_callback(const std::vector<WorkQueue::DataNode *> &batched_data)
+    { wq.peek_batch_callback(batched_data); }
   void set_non_block(bool block) { wq.set_non_block(block);} //set non-blocking calls in wq
 protected:
   /*

--- a/include/work_queue.h
+++ b/include/work_queue.h
@@ -30,7 +30,7 @@ class WorkQueue {
    * @param num_elements  the number of queue slots
    * @param max_elm_size  the maximum size of a data element
    */
-  WorkQueue(int num_elements, int max_elm_size);
+  WorkQueue(size_t num_elements, size_t max_elm_size);
   ~WorkQueue();
 
   /* 
@@ -54,7 +54,7 @@ class WorkQueue {
    * @param batch_size   the amount of Data requested
    * return true if able to get good data, false otherwise
    */
-  bool peek_batch(std::vector<DataNode *> &node_vec, int batch_size);
+  bool peek_batch(std::vector<DataNode *> &node_vec, size_t batch_size);
   
   /* 
    * After processing data taken from the work queue call this function
@@ -62,6 +62,11 @@ class WorkQueue {
    * @param data   the LL node that we have finished processing
    */
   void peek_callback(DataNode *data);
+
+  /*
+   * A batched version of peek_callback that avoids locking on every DataNode
+   */
+  void peek_batch_callback(const std::vector<DataNode *> &node_vec);
 
   void set_non_block(bool _block);
 
@@ -79,8 +84,8 @@ private:
   DataNode *producer_list = nullptr; // list of nodes ready to be written to
   DataNode *consumer_list = nullptr; // list of nodes with data for reading
 
-  const int len;
-  const int max_elm_size;
+  const size_t len;
+  const size_t max_elm_size;
 
   // locks and condition variables for producer list
   std::condition_variable producer_condition;

--- a/test/guttering_systems_test.cpp
+++ b/test/guttering_systems_test.cpp
@@ -76,8 +76,8 @@ static void batch_querier(GutteringSystem *gts, int nodes, int batch_size) {
           ASSERT_EQ(nodes - (key + 1), upd) << "key " << key;
           upd_processed += 1;
         }
-        gts->get_data_callback(data);
       }
+      gts->get_data_batched_callback(data_vec);
     }
     else if(shutdown)
       return;


### PR DESCRIPTION
We can merge the mt_standalone pull request first. This is an optimization that I realized might be nice to have earlier today.