### PR TITLE
One more small adjustment to wq buffering behavior

### DIFF
--- a/src/cache_guttering.cpp
+++ b/src/cache_guttering.cpp
@@ -174,7 +174,10 @@ void CacheGuttering::InsertThread::wq_push_helper(node_id_t node_idx, Leaf_Gutte
 }
 
 void CacheGuttering::InsertThread::flush_wq_buf() {
-  // if wq buffer size is less than expected. Then copy into a smaller buffer before push
+  // if nothing to flush then don't
+  if (local_wq_buffer.size == 0) return;
+
+  // if wq buffer size is less than expected
   if (local_wq_buffer.size < CGsystem.wq_batch_per_elm) {
     // clear the batches beyond wq buffer size
     for (size_t i = local_wq_buffer.size; i < CGsystem.wq_batch_per_elm; i++)


### PR DESCRIPTION
Could get a weird edge case where we push a bunch of completely empty buffers to the work queue. This change ensures that any time we push something to the work queue it contains at least 1 batch with at least 1 update.