### PR TITLE
Better configuration options

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -56,10 +56,10 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ./buffering_tests
+      run: ./guttering_tests
 
     - name: Memory Test (Ubuntu only)
       if: matrix.os == 'ubuntu-latest'
       working-directory: ${{github.workspace}}/build
       shell: bash
-      run: valgrind --leak-check=full ./buffering_tests
+      run: valgrind --leak-check=full ./guttering_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,19 +94,19 @@ endif ()
 target_include_directories(GutterTree PUBLIC include/)
 
 if (BUILD_EXE)
-  add_executable(buffering_tests
+  add_executable(guttering_tests
     test/runner.cpp
     test/guttering_systems_test.cpp
     # test/cache_gutter_tree_test.cpp
   )
-  target_link_libraries(buffering_tests PRIVATE GutterTree)
+  target_link_libraries(guttering_tests PRIVATE GutterTree)
 
-  add_executable(buffering_experiment
+  add_executable(guttering_experiment
     experiment/runner.cpp
     experiment/cache_exp.cpp
     experiment/standalone_exp.cpp)
-  target_link_libraries(buffering_experiment PRIVATE GutterTree)
+  target_link_libraries(guttering_experiment PRIVATE GutterTree)
   if (UNIX AND NOT APPLE)
-    target_compile_options(buffering_experiment PRIVATE -DLINUX_FALLOCATE)
+    target_compile_options(guttering_experiment PRIVATE -DLINUX_FALLOCATE)
   endif()
 endif()

--- a/experiment/cache_exp.cpp
+++ b/experiment/cache_exp.cpp
@@ -36,7 +36,7 @@ static void run_randomized(const int nodes, const unsigned long updates, const u
   size_t fanout       = 64;
   size_t queue_factor = 8;
   size_t num_flushers = 2;
-  float gutter_factor = 1;
+  size_t gutter_size  = 32 * 1024;
   size_t wq_batch     = 8;
 
   auto conf = GutteringConfiguration()
@@ -45,7 +45,7 @@ static void run_randomized(const int nodes, const unsigned long updates, const u
               .fanout(fanout)
               .queue_factor(queue_factor)
               .num_flushers(num_flushers)
-              .gutter_factor(gutter_factor)
+              .gutter_bytes(gutter_size)
               .wq_batch_per_elm(wq_batch);
 
   CacheGuttering *gutters = new CacheGuttering(nodes, num_workers, nthreads, conf);
@@ -117,7 +117,7 @@ static void run_test(const int nodes, const unsigned long updates, const unsigne
               .fanout(64)
               .queue_factor(8)
               .num_flushers(2)
-              .gutter_factor(1)
+              .gutter_bytes(32 * 1024)
               .wq_batch_per_elm(8);
   CacheGuttering *gutters = new CacheGuttering(nodes, num_workers, nthreads, conf);
 

--- a/include/cache_guttering.h
+++ b/include/cache_guttering.h
@@ -121,7 +121,8 @@ class CacheGuttering : public GutteringSystem {
    * @param workers     the number of workers which will be removing batches
    * @param inserters   the number of inserter buffers
    */
-  CacheGuttering(node_id_t nodes, uint32_t workers, uint32_t inserters, const GutteringConfiguration &conf);
+  CacheGuttering(node_id_t nodes, uint32_t workers, uint32_t inserters,
+                 GutteringConfiguration conf);
   CacheGuttering(node_id_t nodes, uint32_t workers, uint32_t inserters) : 
     CacheGuttering(nodes, workers, inserters, GutteringConfiguration()) {};
 

--- a/include/gutter_tree.h
+++ b/include/gutter_tree.h
@@ -80,7 +80,7 @@ public:
    * 
    * @throw GTFileOpenError if the backing file cannot be opened.
    */
-  GutterTree(std::string dir, node_id_t nodes, int workers, const GutteringConfiguration &conf, 
+  GutterTree(std::string dir, node_id_t nodes, int workers, GutteringConfiguration conf, 
     bool reset=false);
   GutterTree(std::string dir, node_id_t nodes, int workers, bool reset=false) :
     GutterTree(dir, nodes, workers, GutteringConfiguration(), reset) {};

--- a/include/guttering_configuration.h
+++ b/include/guttering_configuration.h
@@ -6,45 +6,49 @@ class GutteringSystem;
 class GutteringConfiguration {
 private:
   // write granularity
-  uint32_t _page_size = 8192;
+  size_t _page_size = uninit_param;
   
   // size of an internal node buffer
-  uint32_t _buffer_size = 1 << 23;
+  size_t _buffer_size = uninit_param;
   
   // maximum number of children per node
-  uint32_t _fanout = 64;
+  size_t _fanout = uninit_param;
   
   // total number of batches in queue is this factor * num_workers
-  uint32_t _queue_factor = 8;
+  size_t _queue_factor = uninit_param;
   
   // the number of flush threads
-  uint32_t _num_flushers = 2;
+  size_t _num_flushers = uninit_param;
   
   // the size of each leaf gutter in bytes
-  uint32_t _gutter_bytes = 32 * 1024;
+  size_t _gutter_bytes = uninit_param;
   
   // number of batches placed into or removed from the queue in one push or peek operation
-  size_t _wq_batch_per_elm = 1;
+  size_t _wq_batch_per_elm = uninit_param;
 
   friend class GutteringSystem;
 
 public:
-  GutteringConfiguration();
+  GutteringConfiguration() = default;
+  GutteringConfiguration& set_defaults();
   
   // setters
-  GutteringConfiguration& page_factor(int page_factor);
-  
-  GutteringConfiguration& buffer_exp(int buffer_exp);
-  
-  GutteringConfiguration& fanout(uint32_t fanout);
-  
-  GutteringConfiguration& queue_factor(uint32_t queue_factor);
-  
-  GutteringConfiguration& num_flushers(uint32_t num_flushers);
-  
-  GutteringConfiguration& gutter_bytes(uint32_t gutter_bytes);
-  
+  GutteringConfiguration& page_factor(size_t page_factor);
+  GutteringConfiguration& buffer_exp(size_t buffer_exp);
+  GutteringConfiguration& fanout(size_t fanout);
+  GutteringConfiguration& queue_factor(size_t queue_factor);
+  GutteringConfiguration& num_flushers(size_t num_flushers);
+  GutteringConfiguration& gutter_bytes(size_t gutter_bytes);
   GutteringConfiguration& wq_batch_per_elm(size_t wq_batch_per_elm);
+
+  // getters
+  size_t get_page_size()        { return _page_size; }
+  size_t get_buffer_size()      { return _buffer_size; }
+  size_t get_fanout()           { return _fanout; }
+  size_t get_queue_factor()     { return _queue_factor; }
+  size_t get_num_flushers()     { return _num_flushers; }
+  size_t get_gutter_bytes()     { return _gutter_bytes; }
+  size_t get_wq_batch_per_elm() { return _wq_batch_per_elm; }
 
   friend std::ostream& operator<<(std::ostream& out, const GutteringConfiguration& dt);
 
@@ -54,4 +58,6 @@ public:
   // moving and copying allowed
   GutteringConfiguration(const GutteringConfiguration &) = default;
   GutteringConfiguration (GutteringConfiguration &&) = default;
+
+  static constexpr size_t uninit_param = (size_t) -1;
 };

--- a/include/guttering_configuration.h
+++ b/include/guttering_configuration.h
@@ -20,8 +20,8 @@ private:
   // the number of flush threads
   uint32_t _num_flushers = 2;
   
-  // factor which increases/decreases the leaf gutter size
-  float _gutter_factor = 1;
+  // the size of each leaf gutter in bytes
+  uint32_t _gutter_bytes = 32 * 1024;
   
   // number of batches placed into or removed from the queue in one push or peek operation
   size_t _wq_batch_per_elm = 1;
@@ -42,7 +42,7 @@ public:
   
   GutteringConfiguration& num_flushers(uint32_t num_flushers);
   
-  GutteringConfiguration& gutter_factor(float gutter_factor);
+  GutteringConfiguration& gutter_bytes(uint32_t gutter_bytes);
   
   GutteringConfiguration& wq_batch_per_elm(size_t wq_batch_per_elm);
 

--- a/include/guttering_configuration.h
+++ b/include/guttering_configuration.h
@@ -1,4 +1,7 @@
 #pragma once
+#include <unistd.h>
+#include <iostream>
+#include <string>
 
 // forward declaration
 class GutteringSystem;
@@ -50,7 +53,7 @@ public:
   size_t get_gutter_bytes()     { return _gutter_bytes; }
   size_t get_wq_batch_per_elm() { return _wq_batch_per_elm; }
 
-  friend std::ostream& operator<<(std::ostream& out, const GutteringConfiguration& dt);
+  friend std::ostream& operator<<(std::ostream& out, GutteringConfiguration conf);
 
   // no use of equal operator
   GutteringConfiguration &operator=(const GutteringConfiguration &) = delete;

--- a/include/guttering_system.h
+++ b/include/guttering_system.h
@@ -1,51 +1,57 @@
 #pragma once
-#include "types.h"
-#include "work_queue.h"
-#include "guttering_configuration.h"
 #include <cmath>
 #include <iostream>
 
+#include "guttering_configuration.h"
+#include "types.h"
+#include "work_queue.h"
+
 class GutteringSystem {
-public:
+ public:
   // Constructor for programmatic configuration
-  GutteringSystem(node_id_t num_nodes, int workers, const GutteringConfiguration &conf, bool page_slots=false) : 
-   page_size(conf._page_size), buffer_size(conf._buffer_size), 
-   fanout(conf._fanout), num_flushers(conf._num_flushers), gutter_factor(conf._gutter_factor),
-   queue_factor(conf._queue_factor), wq_batch_per_elm(conf._wq_batch_per_elm),
-   leaf_gutter_size(std::max((int)(conf._gutter_factor * upds_per_sketch(num_nodes)), 1)),
-   wq(workers * queue_factor,
-    page_slots ? leaf_gutter_size + page_size / sizeof(node_id_t) : leaf_gutter_size, 
-    wq_batch_per_elm) {}
-  
-  virtual ~GutteringSystem() {};
-  virtual insert_ret_t insert(const update_t &upd) = 0; //insert an element to the guttering system
-  virtual insert_ret_t insert(const update_t &upd, size_t which) {insert(upd);(void)(which);}; //discard second argument by default
-  virtual flush_ret_t force_flush() = 0;                //force all data out of buffers
+  GutteringSystem(node_id_t num_nodes, int workers, const GutteringConfiguration &conf,
+                  bool page_slots = false)
+      : page_size(conf._page_size),
+        buffer_size(conf._buffer_size),
+        fanout(conf._fanout),
+        num_flushers(conf._num_flushers),
+        queue_factor(conf._queue_factor),
+        wq_batch_per_elm(conf._wq_batch_per_elm),
+        num_nodes(num_nodes),
+        leaf_gutter_size(conf._gutter_bytes / sizeof(node_id_t)),
+        wq(workers * queue_factor,
+           page_slots ? leaf_gutter_size + page_size / sizeof(node_id_t) : leaf_gutter_size,
+           wq_batch_per_elm) {}
+  virtual ~GutteringSystem(){};
+
+  // insert an element to the guttering system
+  // optionally, define insert to include the thread id
+  virtual insert_ret_t insert(const update_t &upd) = 0;
+  virtual insert_ret_t insert(const update_t &upd, size_t thr) {
+    insert(upd);
+    (void)(thr);
+  }
+
+  // force all data out of buffers
+  virtual flush_ret_t force_flush() = 0;
 
   // get the size of a work queue elmement in bytes
-  int gutter_size() {
-    return leaf_gutter_size * sizeof(node_id_t);
-  }
-
-  // returns the number of node_id_t types that fit in a sketch
-  static size_t upds_per_sketch(node_id_t num_nodes) {
-    return 18 * pow(log2(num_nodes), 2) / (log2(3) - 1);
-  }
+  size_t gutter_size() { return leaf_gutter_size * sizeof(node_id_t); }
 
   // get data out of the guttering system either one gutter at a time or in a batched fashion
   bool get_data(WorkQueue::DataNode *&data) { return wq.peek(data); }
   void get_data_callback(WorkQueue::DataNode *data) { wq.peek_callback(data); }
-  void set_non_block(bool block) { wq.set_non_block(block);} //set non-blocking calls in wq
-protected:
+  void set_non_block(bool block) { wq.set_non_block(block); }  // set non-blocking calls in wq
+ protected:
   // parameters of the GutteringSystem, defined by the GutteringConfiguration param or config file
-  const uint32_t page_size;      // guttertree -- write granularity
-  const uint32_t buffer_size;    // guttertree -- internal node buffer size
-  const uint32_t fanout;         // guttertree -- max children per node
-  const uint32_t num_flushers;   // guttertree -- the number of flush threads
-  const float gutter_factor;     // factor which increases/decreases the leaf gutter size
-  const uint32_t queue_factor;   // total number of batches in queue is this factor * num_workers
-  const size_t wq_batch_per_elm; // number of batches each queue element holds
+  const size_t page_size;         // guttertree -- write granularity
+  const size_t buffer_size;       // guttertree -- internal node buffer size
+  const size_t fanout;            // guttertree -- max children per node
+  const size_t num_flushers;      // guttertree -- the number of flush threads
+  const size_t queue_factor;      // total number of batches in queue is this factor * num_workers
+  const size_t wq_batch_per_elm;  // number of batches each queue element holds
 
+  const node_id_t num_nodes;
   node_id_t leaf_gutter_size;
   WorkQueue wq;
 };

--- a/include/guttering_system.h
+++ b/include/guttering_system.h
@@ -9,9 +9,9 @@
 class GutteringSystem {
  public:
   // Constructor for programmatic configuration
-  GutteringSystem(node_id_t num_nodes, int workers, const GutteringConfiguration &conf,
+  GutteringSystem(node_id_t num_nodes, int workers, GutteringConfiguration conf,
                   bool page_slots = false)
-      : page_size(conf._page_size),
+      : page_size((conf.set_defaults())._page_size),  // set defaults first to default init params
         buffer_size(conf._buffer_size),
         fanout(conf._fanout),
         num_flushers(conf._num_flushers),
@@ -52,6 +52,6 @@ class GutteringSystem {
   const size_t wq_batch_per_elm;  // number of batches each queue element holds
 
   const node_id_t num_nodes;
-  node_id_t leaf_gutter_size;
+  const node_id_t leaf_gutter_size;
   WorkQueue wq;
 };

--- a/include/standalone_gutters.h
+++ b/include/standalone_gutters.h
@@ -29,17 +29,17 @@ private:
    */
   insert_ret_t insert_batch(size_t which, node_id_t gutterid);
 
-public:
+ public:
   /**
    * Constructs a new guttering systems using only leaf gutters.
    * @param nodes       number of nodes in the graph.
    * @param workers     the number of workers which will be removing batches
    * @param inserters   the number of inserter buffers
    */
-  StandAloneGutters(node_id_t nodes, uint32_t workers, uint32_t inserters, 
-    const GutteringConfiguration &conf);
-  StandAloneGutters(node_id_t nodes, uint32_t workers, uint32_t inserters) : 
-    StandAloneGutters(nodes, workers, inserters, GutteringConfiguration()) {};
+  StandAloneGutters(node_id_t nodes, uint32_t workers, uint32_t inserters,
+                    GutteringConfiguration conf);
+  StandAloneGutters(node_id_t nodes, uint32_t workers, uint32_t inserters)
+      : StandAloneGutters(nodes, workers, inserters, GutteringConfiguration()){};
 
   /**
    * Puts an update into the data structure.

--- a/src/cache_guttering.cpp
+++ b/src/cache_guttering.cpp
@@ -18,13 +18,15 @@ void CacheGuttering::print_r_to_l(node_id_t src) {
   std::cout << std::endl;
 }
 
-CacheGuttering::CacheGuttering(node_id_t num_nodes, uint32_t workers, uint32_t inserters, 
- const GutteringConfiguration &conf) : GutteringSystem(num_nodes, workers, conf), inserters(inserters), 
- num_nodes(num_nodes), level1_pos(ceil(log2(num_nodes)) - level1_bits),
- level2_pos(std::max((int)ceil(log2(num_nodes)) - level2_bits, 0)), 
- level3_pos(std::max((int)ceil(log2(num_nodes)) - level3_bits, 0)),
- level4_pos(std::max((int)ceil(log2(num_nodes)) - level4_bits, 0)) {
-  
+CacheGuttering::CacheGuttering(node_id_t num_nodes, uint32_t workers, uint32_t inserters,
+                               GutteringConfiguration conf)
+    : GutteringSystem(num_nodes, workers, conf),
+      inserters(inserters),
+      num_nodes(num_nodes),
+      level1_pos(ceil(log2(num_nodes)) - level1_bits),
+      level2_pos(std::max((int)ceil(log2(num_nodes)) - level2_bits, 0)),
+      level3_pos(std::max((int)ceil(log2(num_nodes)) - level3_bits, 0)),
+      level4_pos(std::max((int)ceil(log2(num_nodes)) - level4_bits, 0)) {
   // initialize storage for inserter threads
   insert_threads.reserve(inserters);
   for (uint32_t t = 0; t < inserters; t++) 

--- a/src/gutter_tree.cpp
+++ b/src/gutter_tree.cpp
@@ -15,7 +15,7 @@
  * and the number of nodes we will insert(N)
  * We assume that node indices begin at 0 and increase to N-1
  */
-GutterTree::GutterTree(std::string dir, node_id_t nodes, int workers, const GutteringConfiguration &conf, 
+GutterTree::GutterTree(std::string dir, node_id_t nodes, int workers, GutteringConfiguration conf, 
  bool reset) 
 : GutteringSystem(nodes, workers, conf, true), dir(dir), num_nodes(nodes) {
   if (buffer_size < page_size) {

--- a/src/guttering_configuration.cpp
+++ b/src/guttering_configuration.cpp
@@ -4,22 +4,31 @@
 
 #include "../include/guttering_configuration.h"
 
-GutteringConfiguration::GutteringConfiguration() {
-  _page_size = sysconf(_SC_PAGE_SIZE); // works on POSIX systems (alternative is boost)
-  // Windows may need https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getnativesysteminfo?redirectedfrom=MSDN
+// set any uninitialized parameters to the default values
+GutteringConfiguration& GutteringConfiguration::set_defaults() {
+  if (_page_size == uninit_param)        _page_size        = sysconf(_SC_PAGE_SIZE);
+  if (_buffer_size == uninit_param)      _buffer_size      = 1 << 23;
+  if (_fanout == uninit_param)           _fanout           = 64;
+  if (_queue_factor == uninit_param)     _queue_factor     = 8;
+  if (_num_flushers == uninit_param)     _num_flushers     = 2;
+  if (_gutter_bytes == uninit_param)     _gutter_bytes     = 32 * 1024;
+  if (_wq_batch_per_elm == uninit_param) _wq_batch_per_elm = 1;
+
+  return *this;
 }
 
 // setters
-GutteringConfiguration& GutteringConfiguration::page_factor(int page_factor) {
+GutteringConfiguration& GutteringConfiguration::page_factor(size_t page_factor) {
   if (page_factor > 50 || page_factor < 1) {
     printf("WARNING: page_factor out of bounds [1,50] using default(1)\n");
     page_factor = 1;
   }
+  // sysconf works on POSIX systems. Windows may need something else
   _page_size = page_factor * sysconf(_SC_PAGE_SIZE);
   return *this;
 }
 
-GutteringConfiguration& GutteringConfiguration::buffer_exp(int buffer_exp) {
+GutteringConfiguration& GutteringConfiguration::buffer_exp(size_t buffer_exp) {
   if (buffer_exp > 30 || buffer_exp < 10) {
     printf("WARNING: buffer_exp out of bounds [10,30] using default(20)\n");
     buffer_exp = 20;
@@ -28,7 +37,7 @@ GutteringConfiguration& GutteringConfiguration::buffer_exp(int buffer_exp) {
   return *this;
 }
 
-GutteringConfiguration& GutteringConfiguration::fanout(uint32_t fanout) {
+GutteringConfiguration& GutteringConfiguration::fanout(size_t fanout) {
   _fanout = fanout;
   if (_fanout > 2048 || _fanout < 2) {
     printf("WARNING: fanout out of bounds [2,2048] using default(64)\n");
@@ -37,7 +46,7 @@ GutteringConfiguration& GutteringConfiguration::fanout(uint32_t fanout) {
   return *this;
 }
 
-GutteringConfiguration& GutteringConfiguration::queue_factor(uint32_t queue_factor) {
+GutteringConfiguration& GutteringConfiguration::queue_factor(size_t queue_factor) {
   _queue_factor = queue_factor;
   if (_queue_factor > 1024 || _queue_factor < 1) {
     printf("WARNING: queue_factor out of bounds [1,1024] using default(8)\n");
@@ -46,7 +55,7 @@ GutteringConfiguration& GutteringConfiguration::queue_factor(uint32_t queue_fact
   return *this;
 }
 
-GutteringConfiguration& GutteringConfiguration::num_flushers(uint32_t num_flushers) {
+GutteringConfiguration& GutteringConfiguration::num_flushers(size_t num_flushers) {
   _num_flushers = num_flushers;
   if (_num_flushers > 20 || _num_flushers < 1) {
     printf("WARNING: num_flushers out of bounds [1,20] using default(1)\n");
@@ -55,7 +64,7 @@ GutteringConfiguration& GutteringConfiguration::num_flushers(uint32_t num_flushe
   return *this;
 }
 
-GutteringConfiguration& GutteringConfiguration::gutter_bytes(uint32_t gutter_bytes) {
+GutteringConfiguration& GutteringConfiguration::gutter_bytes(size_t gutter_bytes) {
   _gutter_bytes = gutter_bytes;
   if (_gutter_bytes < 1) {
     printf("WARNING: gutter_bytes must be at least 1, using default(32 KiB)\n");

--- a/src/guttering_configuration.cpp
+++ b/src/guttering_configuration.cpp
@@ -82,12 +82,12 @@ std::ostream& operator<<(std::ostream& out, GutteringConfiguration conf) {
 
   out << "GutteringSystem Configuration:" << std::endl;
   out << " Background threads = " << conf._num_flushers << std::endl;
-  out << " Updates per leaf   = " << conf._gutter_bytes / sizeof(node_id_t) << std::endl;
+  out << " Updates per batch  = " << conf._gutter_bytes / sizeof(node_id_t) << std::endl;
   out << " WQ elements factor = " << conf._queue_factor << std::endl;
   out << " WQ batches per elm = " << conf._wq_batch_per_elm << std::endl;
   out << " GutterTree params:"    << std::endl;
   out << "  Write granularity = " << conf._page_size << std::endl;
-  out << "  Buffer size (MiB) = " << conf._buffer_size / 1024.0 / 1024.0 << std::endl;
+  out << "  Buffer size (KiB) = " << conf._buffer_size / 1024 << std::endl;
   out << "  Fanout            = " << conf._fanout;
   return out;
 }

--- a/src/guttering_configuration.cpp
+++ b/src/guttering_configuration.cpp
@@ -1,8 +1,6 @@
-#include <iostream>
-#include <string>
-#include <unistd.h> //sysconf
-
 #include "../include/guttering_configuration.h"
+
+#include "types.h"
 
 // set any uninitialized parameters to the default values
 GutteringConfiguration& GutteringConfiguration::set_defaults() {
@@ -79,15 +77,17 @@ GutteringConfiguration& GutteringConfiguration::wq_batch_per_elm(size_t wq_batch
   return *this;
 }
 
-std::ostream& operator<<(std::ostream& out, const GutteringConfiguration& conf) {
+std::ostream& operator<<(std::ostream& out, GutteringConfiguration conf) {
+  conf.set_defaults();
+
   out << "GutteringSystem Configuration:" << std::endl;
   out << " Background threads = " << conf._num_flushers << std::endl;
-  out << " Leaf Size in KiB   = " << float(conf._gutter_bytes) / 1024.0 << std::endl;
+  out << " Updates per leaf   = " << conf._gutter_bytes / sizeof(node_id_t) << std::endl;
   out << " WQ elements factor = " << conf._queue_factor << std::endl;
   out << " WQ batches per elm = " << conf._wq_batch_per_elm << std::endl;
   out << " GutterTree params:"    << std::endl;
   out << "  Write granularity = " << conf._page_size << std::endl;
-  out << "  Buffer size       = " << conf._buffer_size << std::endl;
+  out << "  Buffer size (MiB) = " << conf._buffer_size / 1024.0 / 1024.0 << std::endl;
   out << "  Fanout            = " << conf._fanout;
   return out;
 }

--- a/src/guttering_configuration.cpp
+++ b/src/guttering_configuration.cpp
@@ -55,14 +55,12 @@ GutteringConfiguration& GutteringConfiguration::num_flushers(uint32_t num_flushe
   return *this;
 }
 
-GutteringConfiguration& GutteringConfiguration::gutter_factor(float gutter_factor) {
-  _gutter_factor = gutter_factor;
-  if (_gutter_factor < 1 && _gutter_factor > -1) {
-    printf("WARNING: gutter_factor must be outside of range -1 < x < 1 using default(1)\n");
-    _gutter_factor = 1;
+GutteringConfiguration& GutteringConfiguration::gutter_bytes(uint32_t gutter_bytes) {
+  _gutter_bytes = gutter_bytes;
+  if (_gutter_bytes < 1) {
+    printf("WARNING: gutter_bytes must be at least 1, using default(32 KiB)\n");
+    _gutter_bytes = 32 * 1024;
   }
-  if (_gutter_factor < 0)
-    _gutter_factor = 1 / (-1 * _gutter_factor); // gutter factor reduces size if negative
 
   return *this;
 }
@@ -75,7 +73,7 @@ GutteringConfiguration& GutteringConfiguration::wq_batch_per_elm(size_t wq_batch
 std::ostream& operator<<(std::ostream& out, const GutteringConfiguration& conf) {
   out << "GutteringSystem Configuration:" << std::endl;
   out << " Background threads = " << conf._num_flushers << std::endl;
-  out << " Leaf gutter factor = " << conf._gutter_factor << std::endl;
+  out << " Leaf Size in KiB   = " << float(conf._gutter_bytes) / 1024.0 << std::endl;
   out << " WQ elements factor = " << conf._queue_factor << std::endl;
   out << " WQ batches per elm = " << conf._wq_batch_per_elm << std::endl;
   out << " GutterTree params:"    << std::endl;

--- a/src/standalone_gutters.cpp
+++ b/src/standalone_gutters.cpp
@@ -6,9 +6,9 @@
 #include <omp.h>
 #endif
 
-StandAloneGutters::StandAloneGutters(node_id_t num_nodes, uint32_t workers, uint32_t inserters, 
- const GutteringConfiguration &conf) : GutteringSystem(num_nodes, workers, conf), gutters(num_nodes), 
- inserters(inserters) {
+StandAloneGutters::StandAloneGutters(node_id_t num_nodes, uint32_t workers, uint32_t inserters,
+                                     GutteringConfiguration conf)
+    : GutteringSystem(num_nodes, workers, conf), gutters(num_nodes), inserters(inserters) {
   for (node_id_t i = 0; i < num_nodes; ++i) {
     gutters[i].buffer.reserve(leaf_gutter_size);
   }

--- a/src/work_queue.cpp
+++ b/src/work_queue.cpp
@@ -12,12 +12,11 @@ WorkQueue::WorkQueue(size_t total_batches, size_t batch_size, size_t bpe) :
   // place all nodes of linked list in the producer queue and reserve
   // memory for the vectors
   for (size_t i = 0; i < len; i++) {
-    DataNode *node = new DataNode(batch_per_elm, max_batch_size); // create and reserve space for updates
+    // create and reserve space for updates
+    DataNode *node = new DataNode(batch_per_elm, max_batch_size);
     node->next = producer_list; // next of node is head
     producer_list = node; // set head to new node
   }
-
-  printf("WQ: created work queue with %lu elements, each of %lu batch(es), containing %lu updates\n", len, batch_per_elm, max_batch_size);
 }
 
 WorkQueue::~WorkQueue() {

--- a/test/guttering_systems_test.cpp
+++ b/test/guttering_systems_test.cpp
@@ -181,7 +181,7 @@ TEST_P(GuttersTest, TinyGutters) {
   auto conf = GutteringConfiguration()
               .buffer_exp(16)
               .fanout(16)
-              .gutter_factor(-1 * GutteringSystem::upds_per_sketch(nodes))
+              .gutter_bytes(sizeof(node_id_t))
               .queue_factor(1);
 
   run_test(nodes, num_updates, data_workers, GetParam(), conf);
@@ -193,9 +193,8 @@ TEST_P(GuttersTest, FlushAndInsertAgain) {
   const int num_flushes = 3;
   const int data_workers = 20;
 
-  // gutter factor to make buffers size 1
-  auto conf = GutteringConfiguration()
-              .gutter_factor(1);
+  // default configuration
+  auto conf = GutteringConfiguration();
 
   SystemEnum gts_enum = GetParam();
   GutteringSystem *gts;


### PR DESCRIPTION
Previously this code needed to be aware of the size of a Supernode when used in combination with GraphZeppelin. However, one could imaging using this code for another purpose where that wouldn't make much sense and more importantly the size of a Supernode changes and the size we had expected was hard-coded in this repo.

Therefore, users now specify the size of a guttering system leaf in bytes in the configuration. Additionally, we allow arguments to be unspecified in a way that can be seen by those inspecting the configuration. This allows GraphZeppelin to set the size of a leaf if it has not already been set by a user.